### PR TITLE
Fix: contact frontend config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,6 +45,7 @@ serviceId = "senior-accounting-officer-hub-frontend"
 
 contact-frontend {
   host = "http://localhost:9250"
+  serviceId = ${serviceId}
 }
 
 feedback-frontend {


### PR DESCRIPTION
contact-frontend.serviceId must be defined in order for the get help link to appear