### PR TITLE
Saod 405/update scalafix config

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,8 +1,19 @@
 rules = [ExplicitResultTypes, OrganizeImports, RemoveUnused, DisableSyntax]
 
 OrganizeImports {
+  targetDialect = Scala3
   groupedImports = Keep
   coalesceToWildcardImportThreshold = 3
+  removeUnused = true
+  groups = [
+    "*",
+    "scala.",
+    "re:javax?\\."
+  ]
+}
+
+RemoveUnused {
+  imports = false
 }
 
 DisableSyntax {

--- a/app/config/ErrorHandler.scala
+++ b/app/config/ErrorHandler.scala
@@ -22,8 +22,9 @@ import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 import views.html.ErrorTemplate
 
-import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ErrorHandler @Inject() (

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -19,8 +19,9 @@ package controllers.actions
 import play.api.mvc.*
 import requests.IdentifierRequest
 
-import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
 
 class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
 


### PR DESCRIPTION
Updated to address the warning in
https://scalacenter.github.io/scalafix/docs/rules/OrganizeImports.html#configuration
```
Please do NOT use the RemoveUnused.imports together with OrganizeImports to remove unused imports.
```

Also updated to organise import to split `scala.` & `javax?.` import groups