### PR TITLE
SAOD-731 point homepage links to the submission frontend's submission type page

### DIFF
--- a/app/views/HubView.scala.html
+++ b/app/views/HubView.scala.html
@@ -91,7 +91,7 @@
 
     <div id="section-submit-notification-link">
         <p class="govuk-body">
-            <a class="govuk-link" href="@appConfig.submissionFrontendHostAndContext/notification/start">@messages("hub.dashboard.link.submitNotification.text")</a>
+            <a class="govuk-link" href="@appConfig.submissionFrontendHostAndContext/submission-type">@messages("hub.dashboard.link.submitNotification.text")</a>
         </p>
     </div>
 
@@ -132,7 +132,7 @@
 
     <div id="section-submit-certificate-link">
      <p class="govuk-body">
-      <a class="govuk-link" href="@appConfig.submissionFrontendHostAndContext/certificate/start">@messages("hub.dashboard.link.submitCertificate.text")</a>
+      <a class="govuk-link" href="@appConfig.submissionFrontendHostAndContext/submission-type">@messages("hub.dashboard.link.submitCertificate.text")</a>
      </p>
     </div>
 

--- a/test/views/HubViewSpec.scala
+++ b/test/views/HubViewSpec.scala
@@ -163,7 +163,7 @@ class HubViewSpec extends ViewSpecBase[HubView] {
       sectionLink.get(0).text() mustBe "Submit a notification"
       sectionLink
         .get(0)
-        .attr("href") mustBe s"$testSubmissionFrontendHost/senior-accounting-officer/submission/notification/start"
+        .attr("href") mustBe s"$testSubmissionFrontendHost/senior-accounting-officer/submission/submission-type"
     }
 
     "must have correct linkText in submit certificate link section" in {
@@ -175,7 +175,7 @@ class HubViewSpec extends ViewSpecBase[HubView] {
       sectionLink.get(0).text() mustBe "Submit a certificate"
       sectionLink
         .get(0)
-        .attr("href") mustBe s"$testSubmissionFrontendHost/senior-accounting-officer/submission/certificate/start"
+        .attr("href") mustBe s"$testSubmissionFrontendHost/senior-accounting-officer/submission/submission-type"
     }
 
     "must have correct links and text in final link section" in {


### PR DESCRIPTION
# SAOD-731 point homepage links to the submission frontend's submission type page
## List the changes made in comparison to main:
* homepage links altered to point to the submission frontend's submission type page

## Jira ticket(s):
* SAOD-731

## Checklist
* [x] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below