### PR TITLE
POC added test-only protected proxy and get authenthorization routes

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -48,6 +48,8 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
 
   def templateGuidance: String = s"$submissionFrontendHostAndContext/template-guidance"
 
+  def backendBaseUrl: String = servicesConfig.baseUrl("senior-accounting-officer")
+
   private def getValue(key: String): String =
     sys.props
       .get(key)

--- a/app/controllers/testOnly/BackendBaseController.scala
+++ b/app/controllers/testOnly/BackendBaseController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testOnly
+
+import play.api.mvc.{ControllerComponents, RequestHeader}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mdc.RequestMdc
+import uk.gov.hmrc.play.bootstrap.controller.{Utf8MimeTypes, WithJsonBody}
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.util.Try
+
+/** A copy of uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
+  */
+trait BackendBaseController
+    extends play.api.mvc.BaseController
+    with Utf8MimeTypes
+    with WithJsonBody
+    with BackendHeaderCarrierProvider
+
+abstract class BackendController(
+    override val controllerComponents: ControllerComponents
+) extends BackendBaseController
+
+trait BackendHeaderCarrierProvider {
+  implicit protected def hc(implicit request: RequestHeader): HeaderCarrier = {
+    // This is also called by `JsonErrorHandler.onClientError` - see there why we need `Try`
+    Try(request.id).map(RequestMdc.initMdc)
+    HeaderCarrierConverter.fromRequest(request)
+  }
+}

--- a/app/controllers/testOnly/BackendProxyController.scala
+++ b/app/controllers/testOnly/BackendProxyController.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testOnly
+
+import config.AppConfig
+import org.apache.pekko.util.ByteString
+import play.api.http.MimeTypes
+import play.api.libs.ws.{BodyWritable, InMemoryBody}
+import play.api.mvc.{Action, ControllerComponents}
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.http.{HttpResponse, StringContextOps}
+
+import scala.concurrent.ExecutionContext
+
+import java.net.{URL, URLDecoder}
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
+
+class BackendProxyController @Inject() (
+    cc: ControllerComponents,
+    httpClient: HttpClientV2,
+    appConfig: AppConfig
+)(using
+    ExecutionContext
+) extends BackendController(cc) {
+
+  def proxy(path: String): Action[?] = Action(parse.raw).async { implicit request =>
+    val headers =
+      request.headers.headers.filter((header, _) => headersToKeep.exists(_.toLowerCase == header.toLowerCase))
+
+    val bodyString: Option[String] = request.body.asBytes().map(_.utf8String)
+
+    given BodyWritable[String] = BodyWritable(
+      str => InMemoryBody(ByteString(str)),
+      request.headers.headers
+        .collectFirst { case (CONTENT_TYPE, contentType) =>
+          contentType
+        }
+        .fold(MimeTypes.BINARY)(identity)
+    )
+
+    val http: URL => RequestBuilder = request.method match {
+      case "GET"  => httpClient.get(_).setHeader(headers*)
+      case "POST" =>
+        httpClient
+          .post(_: URL)
+          .withBody[String](bodyString.fold("")(identity))
+          .setHeader(headers*)
+      case "PUT" =>
+        httpClient
+          .put(_)
+          .withBody[String](bodyString.fold("")(identity))
+          .setHeader(headers*)
+    }
+
+    val targetUrl = s"${appConfig.backendBaseUrl}/${URLDecoder.decode(path, StandardCharsets.UTF_8)}"
+    http(url"$targetUrl")
+      .execute[HttpResponse]
+      .map(response =>
+        Status(response.status)(response.body).as(response.header(CONTENT_TYPE).fold(MimeTypes.BINARY)(identity))
+      )
+  }
+
+  private def headersToKeep = Seq(
+    CONTENT_TYPE,
+    AUTHORIZATION,
+    "correlationId",
+    "X-Transmitting-System",
+    "X-Originating-System",
+    "X-Receipt-Date"
+  )
+
+}

--- a/app/controllers/testOnly/SessionCookieExtractorController.scala
+++ b/app/controllers/testOnly/SessionCookieExtractorController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testOnly
+
+import play.api.libs.json.*
+import play.api.mvc.*
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+
+import SessionCookieExtractorController.*
+
+class SessionCookieExtractorController @Inject() (mcc: MessagesControllerComponents) extends FrontendController(mcc) {
+  def getAuthorization: Action[AnyContent] = Action { implicit request =>
+    Ok(Json.toJson(Authorization(summon[HeaderCarrier].authorization.map(_.value))))
+  }
+}
+
+object SessionCookieExtractorController {
+  final case class Authorization(authorization: Option[String])
+  object Authorization {
+    given OFormat[Authorization] = Json.format
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -37,6 +37,11 @@ microservice {
       host     = localhost
       port     = 8500
     }
+    senior-accounting-officer {
+      protocol = http
+      host     = localhost
+      port     = 10060
+    }
   }
 }
 

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,11 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+GET        /senior-accounting-officer/test-only/protected-proxy/*path      controllers.testOnly.BackendProxyController.proxy(path)
++nocsrf
+POST       /senior-accounting-officer/test-only/protected-proxy/*path      controllers.testOnly.BackendProxyController.proxy(path)
++nocsrf
+PUT        /senior-accounting-officer/test-only/protected-proxy/*path      controllers.testOnly.BackendProxyController.proxy(path)
+
+GET        /senior-accounting-officer/test-only/authorization              controllers.testOnly.SessionCookieExtractorController.getAuthorization

--- a/it/test/uk/gov/hmrc/senioraccountingofficerhubfrontend/testOnly/BackendProxyISpec.scala
+++ b/it/test/uk/gov/hmrc/senioraccountingofficerhubfrontend/testOnly/BackendProxyISpec.scala
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.senioraccountingofficerhubfrontend.testOnly
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.apache.pekko.util.ByteString
+import play.api.http.{HeaderNames, MimeTypes}
+import play.api.libs.ws.{BodyWritable, InMemoryBody}
+import support.ISpecBase
+import uk.gov.hmrc.http.HeaderCarrier
+import BackendProxyISpec.*
+
+class BackendProxyISpec extends ISpecBase {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  override def additionalConfigs: Map[String, Any] = Map(
+    "microservice.services.senior-accounting-officer.host" -> wireMockHost,
+    "microservice.services.senior-accounting-officer.port" -> wireMockPort,
+    "application.router"                                   -> "testOnlyDoNotUseInAppConf.Routes"
+  )
+
+  "GET /senior-accounting-officer/test-only/protected-proxy/*path" must {
+    "proxy a GET request to our protected service" in {
+      val targetPath           = "/test/url/path"
+      val authHeader           = "testToken"
+      val correlationId        = "id"
+      val transmittingSystem   = "Transmitting-System"
+      val originatingSystem    = "Originating-System"
+      val receiptDate          = "Receipt-Date"
+      val targetResponseStatus = 201
+
+      stubFor(
+        get(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+          )
+      )
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .withHttpHeaders(
+          HeaderNames.AUTHORIZATION -> authHeader,
+          "correlationId"           -> correlationId,
+          "X-Transmitting-System"   -> transmittingSystem,
+          "X-Originating-System"    -> originatingSystem,
+          "X-Receipt-Date"          -> receiptDate
+        )
+        .get()
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        getRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.AUTHORIZATION, equalTo(authHeader))
+          .withHeader("correlationId", equalTo(correlationId))
+          .withHeader("X-Transmitting-System", equalTo(transmittingSystem))
+          .withHeader("X-Originating-System", equalTo(originatingSystem))
+          .withHeader("X-Receipt-Date", equalTo(receiptDate))
+      )
+    }
+
+    "not add Authorization or correlationId header if they are not specified" in {
+      val targetPath           = "/test/url/path"
+      val targetResponseStatus = 202
+
+      stubFor(
+        get(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+          )
+      )
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .get()
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        getRequestedFor(urlEqualTo(targetPath))
+          .withoutHeader(HeaderNames.AUTHORIZATION)
+          .withoutHeader("correlationId")
+      )
+    }
+
+  }
+
+  "POST /senior-accounting-officer/test-only/protected-proxy/*path" must {
+    "proxy a POST request to our protected service" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val correlationId        = "id"
+      val authHeader           = "testToken"
+      val requestContentType   = "application/json"
+      val transmittingSystem   = "Transmitting-System"
+      val originatingSystem    = "Originating-System"
+      val receiptDate          = "Receipt-Date"
+      val targetResponseStatus = 201
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        post(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .withHttpHeaders(
+          HeaderNames.AUTHORIZATION -> authHeader,
+          "correlationId"           -> correlationId,
+          "X-Transmitting-System"   -> transmittingSystem,
+          "X-Originating-System"    -> originatingSystem,
+          "X-Receipt-Date"          -> receiptDate
+        )
+        .post(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.AUTHORIZATION, equalTo(authHeader))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+          .withHeader("correlationId", equalTo(correlationId))
+          .withHeader("X-Transmitting-System", equalTo(transmittingSystem))
+          .withHeader("X-Originating-System", equalTo(originatingSystem))
+          .withHeader("X-Receipt-Date", equalTo(receiptDate))
+          .withRequestBody(equalTo(requestBodyRaw))
+      )
+    }
+
+    "not add Authorization or correlationId header if they are not specified" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val requestContentType   = "application/json"
+      val targetResponseStatus = 202
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        post(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .post(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+          .withoutHeader(HeaderNames.AUTHORIZATION)
+          .withoutHeader("correlationId")
+      )
+    }
+
+    "permit invalid content for the given Content-Type to be sent" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{"
+      val requestContentType   = "application/json"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        post(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .withHttpHeaders(HeaderNames.CONTENT_TYPE -> requestContentType)
+        .post(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+      )
+    }
+
+    "allow invalid content under the specified Content-Type header to be sent" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val requestContentType   = "application/xml"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        post(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .post(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+      )
+    }
+
+    "Content-Type of application/octet-stream will be used if unspecified" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        post(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter("")
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .post(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(MimeTypes.BINARY))
+      )
+    }
+
+  }
+
+  "PUT /senior-accounting-officer/test-only/protected-proxy/*path" must {
+    "proxy a PUT request to our protected service" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val correlationId        = "id"
+      val authHeader           = "testToken"
+      val requestContentType   = "application/json"
+      val transmittingSystem   = "Transmitting-System"
+      val originatingSystem    = "Originating-System"
+      val receiptDate          = "Receipt-Date"
+      val targetResponseStatus = 201
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        put(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .withHttpHeaders(
+          HeaderNames.AUTHORIZATION -> authHeader,
+          "correlationId"           -> correlationId,
+          "X-Transmitting-System"   -> transmittingSystem,
+          "X-Originating-System"    -> originatingSystem,
+          "X-Receipt-Date"          -> receiptDate
+        )
+        .put(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        putRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.AUTHORIZATION, equalTo(authHeader))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+          .withHeader("correlationId", equalTo(correlationId))
+          .withHeader("X-Transmitting-System", equalTo(transmittingSystem))
+          .withHeader("X-Originating-System", equalTo(originatingSystem))
+          .withHeader("X-Receipt-Date", equalTo(receiptDate))
+          .withRequestBody(equalTo(requestBodyRaw))
+      )
+    }
+
+    "not add Authorization or correlationId header if they are not specified" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val requestContentType   = "application/json"
+      val targetResponseStatus = 202
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        put(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .put(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        putRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+          .withoutHeader(HeaderNames.AUTHORIZATION)
+          .withoutHeader("correlationId")
+      )
+    }
+
+    "permit invalid content for the given Content-Type to be sent" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{"
+      val requestContentType   = "application/json"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        put(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .withHttpHeaders(HeaderNames.CONTENT_TYPE -> requestContentType)
+        .put(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        putRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+      )
+    }
+
+    "allow invalid content under the specified Content-Type header to be sent" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val requestContentType   = "application/xml"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        put(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter(requestContentType)
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .put(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        putRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(requestContentType))
+      )
+    }
+
+    "Content-Type of application/octet-stream will be used if unspecified" in {
+      val targetPath           = "/test/url/path"
+      val requestBodyRaw       = "{}"
+      val targetResponseStatus = 203
+      val targetResponseBody   = "test response"
+
+      stubFor(
+        put(urlEqualTo(targetPath))
+          .willReturn(
+            aResponse()
+              .withStatus(targetResponseStatus)
+              .withBody(targetResponseBody)
+          )
+      )
+
+      given BodyWritable[String] = rawStringWriter("")
+
+      val result = wsClient
+        .url(s"$baseUrl/senior-accounting-officer/test-only/protected-proxy$targetPath")
+        .put(requestBodyRaw)
+        .futureValue
+
+      result.status mustBe targetResponseStatus
+
+      verify(
+        1,
+        putRequestedFor(urlEqualTo(targetPath))
+          .withHeader(HeaderNames.CONTENT_TYPE, equalTo(MimeTypes.BINARY))
+      )
+    }
+
+  }
+
+}
+
+object BackendProxyISpec {
+
+  def rawStringWriter(contentType: String): BodyWritable[String] =
+    BodyWritable(
+      str => InMemoryBody(ByteString(str)),
+      contentType
+    )
+
+}

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -12,7 +12,7 @@ object CodeCoverageSettings {
     ".*Routes.*",
     ".*views.*",
     ".*viewmodels.*",
-    "testOnly.*",
+    ".*testOnly.*",
     "testOnlyDoNotUseInAppConf.*"
   )
 


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* created test only route to proxy calls to the protected service
* created test only route to return authorization from the session cookie (or an empty json object if it doesn't exist)

## Jira ticket(s):
* No jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality? (only for the proxy route)
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
