### PR TITLE
SAOD-985 point to hub's own mongo

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -25,6 +25,8 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration) {
 
+  val cacheTtl: Long = config.get[Int]("mongodb.timeToLiveInSeconds")
+
   def welshLanguageSupportEnabled: Boolean =
     config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
 

--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -16,6 +16,7 @@
 
 package repositories
 
+import config.AppConfig
 import models.UserAnswers
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.*
@@ -28,22 +29,28 @@ import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import scala.concurrent.{ExecutionContext, Future}
 
 import java.time.{Clock, Instant}
+import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class SessionRepository @Inject() (
     mongoComponent: MongoComponent,
+    appConfig: AppConfig,
     clock: Clock
 )(using ec: ExecutionContext)
     extends PlayMongoRepository[UserAnswers](
       collectionName = "user-answers",
       mongoComponent = mongoComponent,
       domainFormat = UserAnswers.format,
-      indexes = Seq.empty
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("lastUpdated"),
+          IndexOptions()
+            .name("lastUpdatedIdx")
+            .expireAfter(appConfig.cacheTtl, TimeUnit.SECONDS)
+        )
+      )
     ) {
-
-  // all indexes will be managed by senior-accounting-officer-submission-frontend
-  override lazy val requiresTtlIndex = false
 
   given instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -84,5 +84,6 @@ urls {
 }
 
 mongodb {
-  uri = "mongodb://localhost:27017/senior-accounting-officer-submission-frontend"
+  uri = "mongodb://localhost:27017/"${appName}
+  timeToLiveInSeconds = 900
 }

--- a/it/test/repositories/SessionRepositoryISpec.scala
+++ b/it/test/repositories/SessionRepositoryISpec.scala
@@ -16,7 +16,9 @@
 
 package repositories
 
+import config.AppConfig
 import models.{NominatedCompany, SaoSubscription, UserAnswers}
+import org.mockito.Mockito.when
 import org.mongodb.scala.model.Filters
 import org.scalactic.source.Position
 import org.scalatest.OptionValues
@@ -53,8 +55,12 @@ class SessionRepositoryISpec
   )
   private val userAnswers = UserAnswers("id", subscription, Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
 
+  private val mockAppConfig = mock[AppConfig]
+  when(mockAppConfig.cacheTtl) thenReturn 1L
+  
   protected override val repository: SessionRepository = new SessionRepository(
     mongoComponent = mongoComponent,
+    appConfig = mockAppConfig,
     clock = stubClock
   )(using scala.concurrent.ExecutionContext.Implicits.global)
 


### PR DESCRIPTION
# Pull Request Description
this is a tactical fix
## List the changes made in comparison to main:
* have hub own its own repository and manage the TTLs
   * since hub cannot connect directly to submission's mongo in the environments

## Jira ticket(s):
* [SAOD-985](https://jira.tools.tax.service.gov.uk/browse/SAOD-985)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
