### PR TITLE
SAOD-985 nominated company's CRN is now optional

### DIFF
--- a/app/models/SaoSubscription.scala
+++ b/app/models/SaoSubscription.scala
@@ -29,7 +29,7 @@ object Contact {
   given OFormat[Contact] = Json.format
 }
 
-final case class NominatedCompany(name: String, crn: String, utr: String)
+final case class NominatedCompany(name: String, utr: String, crn: Option[String])
 
 object NominatedCompany {
   given OFormat[NominatedCompany] = Json.format

--- a/it/test/controllers/actions/EnsureSubscriptionActionISpec.scala
+++ b/it/test/controllers/actions/EnsureSubscriptionActionISpec.scala
@@ -216,8 +216,8 @@ object EnsureSubscriptionActionISpec {
       etmpSafeId = etmpSafeId,
       nominatedCompany = NominatedCompany(
         name = companyName,
-        crn = companyCrn,
-        utr = companyUtr
+        utr = companyUtr,
+        crn = Some(companyCrn)
       ),
       contacts = List(
         Contact(name = contact1Name, email = contact1Email, language = contact1Language, status = contact1Status),

--- a/it/test/repositories/SessionRepositoryISpec.scala
+++ b/it/test/repositories/SessionRepositoryISpec.scala
@@ -50,14 +50,14 @@ class SessionRepositoryISpec
 
   val subscription: SaoSubscription = SaoSubscription(
     etmpSafeId = "etmpSafeId",
-    nominatedCompany = NominatedCompany("name", "crn", "utr"),
+    nominatedCompany = NominatedCompany(name = "name", utr = "utr", crn = Some("crn")),
     contacts = List.empty
   )
   private val userAnswers = UserAnswers("id", subscription, Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
 
   private val mockAppConfig = mock[AppConfig]
   when(mockAppConfig.cacheTtl) thenReturn 1L
-  
+
   protected override val repository: SessionRepository = new SessionRepository(
     mongoComponent = mongoComponent,
     appConfig = mockAppConfig,

--- a/test/base/AuthenticatedControllerTestConstants.scala
+++ b/test/base/AuthenticatedControllerTestConstants.scala
@@ -29,7 +29,7 @@ trait AuthenticatedControllerTestConstants {
 
   val subscription: SaoSubscription = SaoSubscription(
     etmpSafeId = etmpSafeId,
-    nominatedCompany = NominatedCompany(companyName, companyCrn, companyUtr),
+    nominatedCompany = NominatedCompany(companyName, companyUtr, Some(companyCrn)),
     contacts = List.empty
   )
 


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* made nominated company's CRN optional as per the latest DPS API

## Jira ticket(s):
*  [SAOD-985](https://jira.tools.tax.service.gov.uk/browse/SAOD-985)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
